### PR TITLE
add inspections for kotlin/native 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -42,9 +42,3 @@ kotlin.stdlib.default.dependency=false
 kotlin.internal.mpp12x.deprecation.suppress=true
 kotlin.mpp.stability.nowarn=true
 kotlin.2js.nowarn=true
-
-JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_271.jdk/Contents/Home
-JDK_16=/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home
-JDK_17=/Library/Java/JavaVirtualMachines/jdk1.7.0_80.jdk/Contents/Home
-JDK_18=/Library/Java/JavaVirtualMachines/jdk1.8.0_271.jdk/Contents/Home
-JDK_9=/Library/Java/JavaVirtualMachines/jdk-9.jdk/Contents/Home

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,3 +42,9 @@ kotlin.stdlib.default.dependency=false
 kotlin.internal.mpp12x.deprecation.suppress=true
 kotlin.mpp.stability.nowarn=true
 kotlin.2js.nowarn=true
+
+JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk1.8.0_271.jdk/Contents/Home
+JDK_16=/Library/Java/JavaVirtualMachines/1.6.0.jdk/Contents/Home
+JDK_17=/Library/Java/JavaVirtualMachines/jdk1.7.0_80.jdk/Contents/Home
+JDK_18=/Library/Java/JavaVirtualMachines/jdk1.8.0_271.jdk/Contents/Home
+JDK_9=/Library/Java/JavaVirtualMachines/jdk-9.jdk/Contents/Home

--- a/idea/resources-en/messages/KotlinBundle.properties
+++ b/idea/resources-en/messages/KotlinBundle.properties
@@ -2151,6 +2151,7 @@ inspection.redundant.elvis.return.null.descriptor=Redundant '?: return null'
 inspection.redundant.elvis.return.null.display.name=Redundant '?: return null'
 inspection.redundant.inner.class.modifier.descriptor=Redundant 'inner' modifier
 inspection.redundant.inner.class.modifier.display.name=Redundant 'inner' modifier
+inspection.native.invalid.mutation.display.name=This mutation will result in an InvalidMutabilityException
 fix.remove.annotation.text=Remove annotation
 inspection.trailing.comma.display.name=Trailing comma recommendations
 inspection.trailing.comma.report.also.a.missing.comma=Report also a missing comma or a line break

--- a/idea/resources/META-INF/inspections.xml
+++ b/idea/resources/META-INF/inspections.xml
@@ -2579,6 +2579,29 @@
                      language="kotlin"
                      key="inspection.unused.result.of.data.class.copy" bundle="messages.KotlinBundle"/>
 
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.MutationOfVariableFromInitializerInEnumInNativeInspection"
+                     groupPath="Kotlin"
+                     groupName="Probable bugs"
+                     enabledByDefault="true"
+                     level="WARNING"
+                     language="kotlin"
+                     key="inspection.native.invalid.mutation.display.name" bundle="messages.KotlinBundle"/>
+
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.MutationOfVariableInObjectOrEnumInNativeInspection"
+                     groupPath="Kotlin"
+                     groupName="Probable bugs"
+                     enabledByDefault="true"
+                     level="WARNING"
+                     language="kotlin"
+                     key="inspection.native.invalid.mutation.display.name" bundle="messages.KotlinBundle"/>
+
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.MutationOfVariableWithSharedImmutableAnnotationInNativeInspection"
+                     groupPath="Kotlin"
+                     groupName="Probable bugs"
+                     enabledByDefault="true"
+                     level="WARNING"
+                     language="kotlin"
+                     key="inspection.native.invalid.mutation.display.name" bundle="messages.KotlinBundle"/>
   </extensions>
 
 </idea-plugin>

--- a/idea/src/org/jetbrains/kotlin/idea/inspections/MutationOfVariableFromInitializerInEnumInNativeInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/MutationOfVariableFromInitializerInEnumInNativeInspection.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.inspections
+
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.search.searches.ReferencesSearch
+import org.jetbrains.kotlin.idea.KotlinBundle
+import org.jetbrains.kotlin.idea.project.platform
+import org.jetbrains.kotlin.idea.references.KtSimpleNameReference
+import org.jetbrains.kotlin.idea.references.readWriteAccess
+import org.jetbrains.kotlin.platform.konan.isNative
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
+
+class MutationOfVariableFromInitializerInEnumInNativeInspection: AbstractKotlinInspection() {
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+        parameterVisitor(fun(parameter) {
+            if (!parameter.platform.isNative()) return
+            if (!(parameter.containingClassOrObject as KtClass).isEnum()) return
+            if (!parameter.isMutable) return
+
+            val references = ReferencesSearch.search(parameter, parameter.useScope).filter {
+                (it as? KtSimpleNameReference)
+                    ?.element
+                    ?.readWriteAccess(useResolveForReadWrite = true)
+                    ?.isWrite == true
+            }
+
+            references.forEach {
+                holder.registerProblem(
+                    it.element,
+                    KotlinBundle.message("inspection.native.invalid.mutation.display.name"),
+                    ProblemHighlightType.GENERIC_ERROR_OR_WARNING
+                )
+            }
+        })
+}

--- a/idea/src/org/jetbrains/kotlin/idea/inspections/MutationOfVariableInObjectOrEnumInNativeInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/MutationOfVariableInObjectOrEnumInNativeInspection.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.inspections
+
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.search.searches.ReferencesSearch
+import org.jetbrains.kotlin.idea.KotlinBundle
+import org.jetbrains.kotlin.idea.project.platform
+import org.jetbrains.kotlin.idea.references.KtSimpleNameReference
+import org.jetbrains.kotlin.idea.references.readWriteAccess
+import org.jetbrains.kotlin.platform.konan.isNative
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
+
+class MutationOfVariableInObjectOrEnumInNativeInspection: AbstractKotlinInspection() {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+        propertyVisitor(fun(property) {
+            if (!property.platform.isNative()) return
+            if (!property.isVar) return
+
+            val classOrObject = property.containingClassOrObject ?: return
+            val isEnumDeclaration = (classOrObject as? KtClass)?.isEnum() ?: false
+            val isObjectDeclaration = classOrObject is KtObjectDeclaration
+
+            if (!(isEnumDeclaration || isObjectDeclaration)) return
+
+            if (classOrObject.annotationEntries.map { it.shortName.toString() }.contains("ThreadLocal")) return
+
+            val references = ReferencesSearch.search(property, property.useScope).filter {
+                (it as? KtSimpleNameReference)
+                    ?.element
+                    ?.readWriteAccess(true)
+                    ?.isWrite == true
+            }
+
+            references.forEach {
+                holder.registerProblem(
+                    it.element,
+                    KotlinBundle.message("inspection.native.invalid.mutation.display.name"),
+                    ProblemHighlightType.GENERIC_ERROR_OR_WARNING
+                )
+            }
+        })
+}

--- a/idea/src/org/jetbrains/kotlin/idea/inspections/MutationOfVariableWithSharedImmutableAnnotationInNativeInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/MutationOfVariableWithSharedImmutableAnnotationInNativeInspection.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Use of this source code is governed by the Apache 2.0 license that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.inspections
+
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.search.searches.ReferencesSearch
+import org.jetbrains.kotlin.idea.KotlinBundle
+import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.idea.intentions.getCallableDescriptor
+import org.jetbrains.kotlin.idea.project.platform
+import org.jetbrains.kotlin.idea.references.KtSimpleNameReference
+import org.jetbrains.kotlin.idea.references.readWriteAccess
+import org.jetbrains.kotlin.platform.konan.isNative
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.resolve.source.getPsi
+import com.intellij.psi.PsiReference as PsiReference
+
+class MutationOfVariableWithSharedImmutableAnnotationInNativeInspection: AbstractKotlinInspection() {
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
+        propertyVisitor(fun(property) {
+            if (!property.platform.isNative()) return
+            if (!(property.annotationEntries.map { it.shortName.toString() }.contains("SharedImmutable"))) return
+
+            val callableDescriptor = property.delegateExpressionOrInitializer?.getCallableDescriptor()
+            val psi = callableDescriptor?.source?.getPsi() ?: return
+
+            var classProperties = listOf<KtProperty>()
+            var valueParameters = listOf<KtParameter>()
+
+            when (psi) {
+                is KtClass ->
+                    classProperties = psi.getProperties()
+                is KtPrimaryConstructor -> {
+                    valueParameters = psi.valueParameters
+                    classProperties = (psi.parent as? KtClass)?.getProperties() ?: emptyList()
+                }
+            }
+
+            fun searchWriteReferences(element: PsiElement): List<PsiReference> {
+                return ReferencesSearch.search(element, element.useScope)
+                    .filter {
+                        (it as? KtSimpleNameReference)
+                            ?.element
+                            ?.readWriteAccess(true)
+                            ?.isWrite == true
+                    }
+            }
+
+            fun registerProblem(element: PsiElement) {
+                holder.registerProblem(
+                    element,
+                    KotlinBundle.message("inspection.native.invalid.mutation.display.name"),
+                    ProblemHighlightType.GENERIC_ERROR_OR_WARNING
+                )
+            }
+            
+            valueParameters.forEach {
+                if (!it.isMutable) return@forEach
+                searchWriteReferences(it).forEach {
+                   registerProblem(it.element)
+                }
+            }
+
+            classProperties?.forEach {
+                if (!it.isVar) return@forEach
+                searchWriteReferences(it).forEach {
+                    registerProblem(it.element)
+                }
+            }
+        })
+}


### PR DESCRIPTION
added new inspections for Kotlin/Native:
  - MutationOfVariableInObjectOrEnumInNativeInspection
  - MutationOfVariableFromInitializerInEnumInNativeInspection
  - MutationOfVariableWithSharedImmutableAnnotationInNativeInspection